### PR TITLE
fix: webpack 5 RuleSet error by bumping svg-sprite-loader version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "laravel-mix-svg-sprite",
   "description": "SVG sprite component for Laravel Mix",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "keywords": [
     "laravel",
     "mix",
@@ -25,7 +25,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "svg-sprite-loader": "^4.1.3",
+    "svg-sprite-loader": "^5.2.1",
     "svgo": "^1.0.0",
     "svgo-loader": "^2.1.0"
   },


### PR DESCRIPTION
When using Webpack 5 the mix crashes with `Error: Cannot find module 'webpack/lib/RuleSet'`.
Multiple reports of this issue can be found here: https://github.com/JetBrains/svg-sprite-loader/issues?q=webpack%2Flib%2FRuleset
Solution is found here: https://github.com/JetBrains/svg-sprite-loader/issues/413